### PR TITLE
Use "/usr/bin/env python" instead of "/usr/bin/python"

### DIFF
--- a/youtube-dl-server
+++ b/youtube-dl-server
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Author: Janez Troha


### PR DESCRIPTION
This helps to use the script unchanged on machines which may not have python2 as default.
See : https://wiki.archlinux.org/index.php/python#Python_2
