### PR TITLE
Fix argument in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ GITHUB=https://github.com/dz0ny/youtube-dl-server
 rm -rf ~/youtube-dl-server
 mkdir ~/youtube-dl-server
 cd ~/youtube-dl-server
-curl -L $GITHUB/tarball/master -O ./youtube-dl-server.tar.gz
+curl -L $GITHUB/tarball/master -o ./youtube-dl-server.tar.gz
 tar -zxvf ./youtube-dl-server.tar.gz --strip 1
 rm ./youtube-dl-server.tar.gz
 rm ./install.sh


### PR DESCRIPTION
```
       -o, --output <file>
              Write output to <file> instead of stdout. 

       -O, --remote-name
              Write  output  to  a local file named like the remote file we get.
```
